### PR TITLE
Allow github token to be retrieved from a deferred function

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -93,21 +93,22 @@ define github_actions_runner::instance (
     require      => File["${github_actions_runner::root_dir}/${instance_name}"],
   }
 
+  $data = {
+    personal_access_token => $personal_access_token,
+    token_url             => $token_url,
+    instance_name         => $instance_name,
+    root_dir              => $github_actions_runner::root_dir,
+    url                   => $url,
+    hostname              => $hostname,
+    assured_labels        => $assured_labels,
+    disable_update        => $disable_update,
+  }
   file { "${github_actions_runner::root_dir}/${name}/configure_install_runner.sh":
     ensure  => $ensure,
     mode    => '0755',
     owner   => $user,
     group   => $group,
-    content => epp('github_actions_runner/configure_install_runner.sh.epp', {
-        personal_access_token => $personal_access_token,
-        token_url             => $token_url,
-        instance_name         => $instance_name,
-        root_dir              => $github_actions_runner::root_dir,
-        url                   => $url,
-        hostname              => $hostname,
-        assured_labels        => $assured_labels,
-        disable_update        => $disable_update,
-    }),
+    content => stdlib::deferrable_epp('github_actions_runner/configure_install_runner.sh.epp', $data),
     notify  => Exec["${instance_name}-run_configure_install_runner.sh"],
     require => Archive["${instance_name}-${archive_name}"],
   }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 1.0.0 < 7.0.0"
+      "version_requirement": ">= 8.4.0 < 10.0.0"
     },
     {
       "name": "camptocamp/systemd",

--- a/templates/configure_install_runner.sh.epp
+++ b/templates/configure_install_runner.sh.epp
@@ -1,7 +1,7 @@
 <%- | String $personal_access_token,
       String $token_url,
       String $instance_name,
-      Stdlib::Absolutepath $root_dir,
+      String $root_dir,
       String $url,
       String $hostname,
       String $assured_labels,


### PR DESCRIPTION
This allows you to

```
class{'github_actions_runner':
  personal_access_token => Deferred('secret::get',['poc']),
}
```

for the existing case where a string is used the module will operate in the same way.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
