### PR TITLE
Support adding runner to runner groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ github_actions_runner::instances:
   example_org_instance:
     labels:
       - self-hosted-custom
+    runner_group: 'MyRunners'
 ```
 
 Note, your `personal_access_token` has to contain the `admin:org` permission.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -222,6 +222,7 @@ The following parameters are available in the `github_actions_runner::instance` 
 * [`labels`](#-github_actions_runner--instance--labels)
 * [`path`](#-github_actions_runner--instance--path)
 * [`env`](#-github_actions_runner--instance--env)
+* [`runner_group`](#-github_actions_runner--instance--runner_group)
 
 ##### <a name="-github_actions_runner--instance--ensure"></a>`ensure`
 
@@ -366,4 +367,12 @@ Data type: `Optional[Hash[String, String]]`
 List of variables to be used as env variables in the instance runner. If not defined, file ".env" will be kept as created by the runner scripts. (Default: Value set by github_actions_runner Class)
 
 Default value: `$github_actions_runner::env`
+
+##### <a name="-github_actions_runner--instance--runner_group"></a>`runner_group`
+
+Data type: `Optional[String[1]]`
+
+The github runner group to add the runner to.
+
+Default value: `undef`
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -20,6 +20,7 @@
 # @param labels A list of costum lables to add to a runner.
 # @param path List of paths to be used as PATH env in the instance runner. If not defined, file ".path" will be kept as created by the runner scripts. (Default: Value set by github_actions_runner Class)
 # @param env List of variables to be used as env variables in the instance runner. If not defined, file ".env" will be kept as created by the runner scripts. (Default: Value set by github_actions_runner Class)
+# @param runner_group The github runner group to add the runner to.
 #
 define github_actions_runner::instance (
   Enum['present', 'absent']      $ensure                = 'present',
@@ -40,6 +41,7 @@ define github_actions_runner::instance (
   Optional[String[1]]            $repo_name             = undef,
   Optional[Array[String]]        $path                  = $github_actions_runner::path,
   Optional[Hash[String, String]] $env                   = $github_actions_runner::env,
+  Optional[String[1]]            $runner_group          = undef,
 ) {
   if $labels {
     $flattend_labels_list=join($labels, ',')
@@ -102,6 +104,7 @@ define github_actions_runner::instance (
     hostname              => $hostname,
     assured_labels        => $assured_labels,
     disable_update        => $disable_update,
+    runner_group          => $runner_group,
   }
   file { "${github_actions_runner::root_dir}/${name}/configure_install_runner.sh":
     ensure  => $ensure,

--- a/templates/configure_install_runner.sh.epp
+++ b/templates/configure_install_runner.sh.epp
@@ -5,6 +5,7 @@
       String $url,
       String $hostname,
       String $assured_labels,
+      Optional[String[1]] $runner_group = undef,
       Boolean $disable_update,
 | -%>
 #!/bin/bash
@@ -33,6 +34,9 @@ export RUNNER_ALLOW_RUNASROOT=true
   --name <%= $hostname %>-<%= $instance_name %>  \
   --url <%= $url %>                              \
   --token ${TOKEN}                               \
+  <%- if $runner_group { -%>
+  --runnergroup <%= $runner_group %>             \
+  <%- } -%>
   <%- if $disable_update { -%>
   --disableupdate                                \
   <%- } -%>


### PR DESCRIPTION
Allow a per instance `runner_group` to be specified to pupulate the `--runnergroup` option to `config.sh`

* https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/managing-access-to-self-hosted-runners-using-groups

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
