### PR TITLE
metadata.json: Drop deprecated data_provider attribute

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,6 @@
       "version_requirement": ">= 1.1.2 < 5.0.0"
     }
   ],
-  "data_provider": "hiera",
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",


### PR DESCRIPTION
This yields:

```
Warning: Defining "data_provider": "hiera" in metadata.json is deprecated. A 'hiera.yaml' file should be used instead
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
