### PR TITLE
Allow treating personal Github PAT as Sensitive

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -76,7 +76,7 @@ Default value: `undef`
 
 ##### <a name="-github_actions_runner--personal_access_token"></a>`personal_access_token`
 
-Data type: `String[1]`
+Data type: `Variant[Sensitive[String[1]],String[1]]`
 
 GitHub PAT with admin permission on the repositories or the origanization.
 
@@ -251,7 +251,7 @@ Default value: `$github_actions_runner::enterprise_name`
 
 ##### <a name="-github_actions_runner--instance--personal_access_token"></a>`personal_access_token`
 
-Data type: `String[1]`
+Data type: `Variant[Sensitive[String[1]],String[1]]`
 
 GitHub PAT with admin permission on the repositories or the origanization.(Default: Value set by github_actions_runner Class)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@
 # @param env List of variables to be used as env variables in the instance runner. If not defined, file ".env" will be kept as created by the runner scripts. (Default: Value set by github_actions_runner Class)
 #
 class github_actions_runner (
-  String[1]                      $personal_access_token = 'PAT',
+  Variant[Sensitive[String[1]],String[1]] $personal_access_token = 'PAT',
   Enum['present', 'absent']      $ensure = 'present',
   Stdlib::Absolutepath           $base_dir_name = '/some_dir/actions-runner',
   String[1]                      $package_name = $facts['os']['architecture'] ? { /x86_64|amd64/ => 'actions-runner-linux-x64', 'aarch64' => 'actions-runner-linux-arm64' },

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -25,7 +25,7 @@
 #
 define github_actions_runner::instance (
   Enum['present', 'absent']      $ensure                = 'present',
-  String[1]                      $personal_access_token = $github_actions_runner::personal_access_token,
+  Variant[Sensitive[String[1]],String[1]] $personal_access_token = $github_actions_runner::personal_access_token,
   Optional[Variant[Sensitive[String[1]],String[1]]] $repo_token = undef,
   String[1]                      $user                  = $github_actions_runner::user,
   String[1]                      $group                 = $github_actions_runner::group,

--- a/spec/classes/github_actions_runner_spec.rb
+++ b/spec/classes/github_actions_runner_spec.rb
@@ -324,6 +324,16 @@ describe 'github_actions_runner' do
         end
       end
 
+      context 'is expected to create a github_actions_runner installation script with test_PAT in content when using as Sensitive' do
+        let(:params) do
+          super().merge('personal_access_token' => sensitive('test_PAT'))
+        end
+
+        it do
+          is_expected.to contain_file('/some_dir/actions-runner-2.319.1/first_runner/configure_install_runner.sh').with_content(%r{authorization: token test_PAT})
+        end
+      end
+
       context 'is expected to create a github_actions_runner installation script with disableupdate in content' do
         let(:params) do
           super().merge('disable_update' => true)

--- a/templates/configure_install_runner.sh.epp
+++ b/templates/configure_install_runner.sh.epp
@@ -1,4 +1,4 @@
-<%- | String $personal_access_token,
+<%- | Variant[Sensitive,String] $personal_access_token,
       String $token_url,
       String $instance_name,
       String $root_dir,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add the option to treat personal_access_token as a Sensitive object instead of a plain string.

#### This Pull Request (PR) fixes the following issues
Fixes #30 
